### PR TITLE
Bumped edireader library version, upgraded processor bundle version to be independent from Nifi version, fixed tests on Windows, fixed static analysis code unconventional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 ## Directory-based project format:
 .idea/
+.vscode/
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ documents into XML using the
 ```bash
 > cd nifi-edireader-processor
 > mvn package
-> cp nifi-edireader-nar/target/nifi-edireader-nar-1.9.2.nar /NIFI_INSTALL/lib/
+> cp nifi-edireader-nar/target/nifi-edireader-nar-2.0.0.nar /NIFI_INSTALL/lib/
 ```
 
 ## License

--- a/nifi-edireader-nar/pom.xml
+++ b/nifi-edireader-nar/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>nifi-edireader-bundle</artifactId>
         <groupId>org.apache.nifi</groupId>
-        <version>1.9.2</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>nifi-edireader-nar</artifactId>
-    <version>1.9.2</version>
+    <version>2.0.0</version>
     <packaging>nar</packaging>
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-edireader-processors</artifactId>
-            <version>1.9.2</version>
+            <version>2.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-edireader-processors/pom.xml
+++ b/nifi-edireader-processors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nifi-edireader-bundle</artifactId>
         <groupId>org.apache.nifi</groupId>
-        <version>1.9.2</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nifi-edireader-processors/pom.xml
+++ b/nifi-edireader-processors/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.berryworks</groupId>
             <artifactId>edireader</artifactId>
-            <version>5.4.17</version>
+            <version>5.6.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/EdiToXML.java
+++ b/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/EdiToXML.java
@@ -2,7 +2,6 @@ package org.apache.nifi.processors.edireader;
 
 import com.berryworks.edireader.EDIParserFactory;
 
-import com.berryworks.edireader.error.MissingMandatoryElementException;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;

--- a/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/split/Interchange.java
+++ b/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/split/Interchange.java
@@ -53,7 +53,7 @@ class Interchange {
 
     public Map<String, String> writer() {
 
-        Map results = new HashMap();
+        Map<String, String> results = new HashMap<>();
 
         transactions.forEach(t -> {
 

--- a/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/split/Splitter.java
+++ b/nifi-edireader-processors/src/main/java/org/apache/nifi/processors/edireader/split/Splitter.java
@@ -88,6 +88,7 @@ public class Splitter {
                     break;
             }
         }
+        scanner.close();
         return flowFiles;
     }
 

--- a/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/EdiToJSONTest.java
+++ b/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/EdiToJSONTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -68,10 +67,13 @@ public class EdiToJSONTest {
 
         MockFlowFile result = results.get(0);
 
-        byte[] bytes = Files.readAllBytes(Paths.get(output));
+        // Change line ending of the output file to be inline with the operating system line separator
+        File outputFile = FileUtils.getFile(output);
+        String outputContent = FileUtils.readFileToString(outputFile, Charset.defaultCharset());
+        outputContent = outputContent.replaceAll("\n", System.getProperty("line.separator"));
 
         // Test attributes and content
-        result.assertContentEquals(bytes);
+        result.assertContentEquals(outputContent.getBytes(Charset.defaultCharset()));
     }
 
     @Test
@@ -91,10 +93,13 @@ public class EdiToJSONTest {
 
         MockFlowFile result = results.get(0);
 
-        byte[] bytes = Files.readAllBytes(Paths.get(output));
+        // Change line ending of the output file to be inline with the operating system line separator
+        File outputFile = FileUtils.getFile(output);
+        String outputContent = FileUtils.readFileToString(outputFile, Charset.defaultCharset());
+        outputContent = outputContent.replaceAll("\n", System.getProperty("line.separator"));
 
         // Test attributes and content
-        result.assertContentEquals(bytes);
+        result.assertContentEquals(outputContent.getBytes(Charset.defaultCharset()));
     }
 
     @Test
@@ -117,7 +122,7 @@ public class EdiToJSONTest {
     }
 
     private String ediFile(String fileName) {
-        return this.getClass().getResource(fileName).getPath();
+        return new File(this.getClass().getResource(fileName).getPath()).toPath().toString();
     }
 
 }

--- a/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/EdiToXMLTest.java
+++ b/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/EdiToXMLTest.java
@@ -66,6 +66,6 @@ public class EdiToXMLTest {
     }
 
     private String ediFile(String fileName) {
-        return this.getClass().getResource(fileName).getPath();
+        return new File(this.getClass().getResource(fileName).getPath()).toPath().toString();
     }
 }

--- a/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/SplitEdiTest.java
+++ b/nifi-edireader-processors/src/test/java/org/apache/nifi/processors/edireader/SplitEdiTest.java
@@ -87,6 +87,6 @@ public class SplitEdiTest {
     }
 
     private String ediFile(String fileName) {
-        return this.getClass().getResource(fileName).getPath();
+        return new File(this.getClass().getResource(fileName).getPath()).toPath().toString();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <artifactId>nifi-edireader-bundle</artifactId>
-    <version>1.9.2</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
### Bumped edireader library version
Berryworks edireader version has been upgraded from 5.4.17 to 5.6.5. This allows the developer to be in line with the latest version as 5.4.17 is not a tagged version and doesn't allow to package the processor. Version 5.6.5 hasn't been released yet, but I hope it will be soon, otherwise, it is also possible to use the last available tagged versions (5.6.0 or 5.6.4). In this way, the processor can reference an updated library and it can be built in case of any patch / bug / enhancement.

### Upgraded processor bundle version to be independent of NiFi version
The processor version must be independent of the Nifi version as it also has other dependencies. The component bundle version should be managed when there are new changes to the repository (bug fixes, dependency upgrades, enhancements). Still better to use "-SNAPSHOT" version to consider a development version not released yet.
IMHO, it is better to re-start from a higher version to avoid incompatibility, so I moved to 2.0.0.
_Example: The developer would like to upgrade berryworks edireader version without bumping Nifi version. It can be possible by structuring the component version as independent wrt the Nifi version._

### Fixed tests on Windows
Tests are now working on Windows platform as well as Linux / Mac. It is now possible to build and package the component processor on Windows as well. It fixes the issue: #10 .

### Fixed static analysis code unconventional
Closed scanner at the end of the loop, added explicit types on Java Map, removed unused imports.

### Testing
The testing phase has been performed on Windows and Mac for the building phase, on Nifi 1.23.2 to test the component (backward compatibility). Nifi has been deployed on a clusterized environment using helm (https://github.com/cetic/helm-nifi) with version 1.2.0. EDIs have been parsed correctly as the same as the latest released processor version (1.9.2).

For any questions, feel free to contact me:
Lorenzo Vangi
lorenzo-vangi@dedagroup.it
lorenzovangi@gmail.com

Looking forward to hearing from you,
Regards.

